### PR TITLE
Add error message to csv output

### DIFF
--- a/src/program/output.py
+++ b/src/program/output.py
@@ -141,7 +141,7 @@ class OutputManager():
         for group in self.result:
             for error in group["errors"]:
                 print("%s,%s,%s,%d" % (
-                    error["severity"], error["code"], error["file"], error["line"]))
+                    error["severity"], error["code"] + " - " + error["message"], error["file"], error["line"]))
 
     def showAs(self, type):
         if (type == "default"):


### PR DESCRIPTION
Coding style error codes by themselves are not valuable information, combining it with the message makes csv output much better for easy use as a linter (how I use it).